### PR TITLE
DDST-188: Alternative Logger

### DIFF
--- a/dgi_fixity.services.yml
+++ b/dgi_fixity.services.yml
@@ -1,7 +1,7 @@
 services:
   dgi_fixity.fixity_check:
     class: Drupal\dgi_fixity\FixityCheckService
-    arguments: ['@string_translation', '@config.factory', '@entity_type.manager', '@datetime.time', '@filehash']
+    arguments: ['@string_translation', '@config.factory', '@entity_type.manager', '@datetime.time', '@logger.channel.dgi_fixity', '@filehash']
     calls:
       - [setLoggerFactory, ['@logger.factory']]
   dgi_fixity.route_subscriber:
@@ -15,6 +15,5 @@ services:
     tags:
       - { name: paramconverter }
   logger.channel.dgi_fixity:
-    class: Drupal\Core\Logger\LoggerChannel
-    factory: logger.factory:get
+    parent: logger.channel_base
     arguments: ['dgi_fixity']

--- a/dgi_fixity.services.yml
+++ b/dgi_fixity.services.yml
@@ -2,8 +2,6 @@ services:
   dgi_fixity.fixity_check:
     class: Drupal\dgi_fixity\FixityCheckService
     arguments: ['@string_translation', '@config.factory', '@entity_type.manager', '@datetime.time', '@logger.channel.dgi_fixity', '@filehash']
-    calls:
-      - [setLoggerFactory, ['@logger.factory']]
   dgi_fixity.route_subscriber:
     class: Drupal\dgi_fixity\Routing\FixityCheckRouteSubscriber
     arguments: ['@entity_type.manager', '@dgi_fixity.fixity_check']

--- a/src/FixityCheckService.php
+++ b/src/FixityCheckService.php
@@ -7,7 +7,6 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Link;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\dgi_fixity\Entity\FixityCheck;
@@ -18,6 +17,7 @@ use Drupal\filehash\FileHash;
 use Drupal\media\MediaInterface;
 use Drupal\views\ViewExecutable;
 use Drupal\views\Views;
+use Psr\Log\LoggerInterface;
 
 /**
  * Decorates the FileHash services adding additional functionality.
@@ -62,13 +62,6 @@ class FixityCheckService implements FixityCheckServiceInterface {
   protected $filehash;
 
   /**
-   * The logger factory.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
-   */
-  protected LoggerChannelFactoryInterface $loggerFactory;
-
-  /**
    * Constructor.
    */
   public function __construct(
@@ -76,36 +69,15 @@ class FixityCheckService implements FixityCheckServiceInterface {
     ConfigFactoryInterface $config,
     EntityTypeManagerInterface $entity_type_manager,
     TimeInterface $time,
+    LoggerInterface $logger,
     FileHash $filehash
   ) {
     $this->stringTranslation = $string_translation;
     $this->config = $config;
     $this->entityTypeManager = $entity_type_manager;
     $this->time = $time;
+    $this->logger = $logger;
     $this->filehash = $filehash;
-  }
-
-  /**
-   * Sets the logger factory.
-   *
-   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
-   *   The logger factory.
-   */
-  public function setLoggerFactory(LoggerChannelFactoryInterface $loggerFactory) {
-    $this->loggerFactory = $loggerFactory;
-  }
-
-  /**
-   * Gets the logger channel.
-   *
-   * @return \Psr\Log\LoggerInterface
-   *   The logger channel.
-   */
-  protected function getLogger() {
-    if (!isset($this->logger)) {
-      $this->logger = $this->loggerFactory->get('dgi_fixity');
-    }
-    return $this->logger;
   }
 
   /**
@@ -298,10 +270,10 @@ class FixityCheckService implements FixityCheckServiceInterface {
       )->toString(),
     ];
     if ($check->passed()) {
-      $this->getLogger()->info($message, $args);
+      $this->logger->info($message, $args);
     }
     else {
-      $this->getLogger()->error($message, $args);
+      $this->logger->error($message, $args);
     }
 
     return $check;


### PR DESCRIPTION
This isn't entirely necessary, created just incase we need to stick more towards established methods of creating and using loggers, other than seemingly to create a unique logger via factory for this one instance.

The circular dependency that was being encountered previously (and the reason for this fix) was related to missing/errored configuration in the environment.